### PR TITLE
Refactor and use net-ssh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.ruby-version
+.ruby-gemset

--- a/lib/vagrant/scp/commands/scp.rb
+++ b/lib/vagrant/scp/commands/scp.rb
@@ -47,7 +47,7 @@ module VagrantPlugins
 
         def parse_args
           opts = OptionParser.new do |o|
-            o.banner = "Usage: vagrant scp <local_path> [vm_name]:<remote_path> \n"
+            o.banner =  "Usage: vagrant scp <local_path> [vm_name]:<remote_path> \n"
             o.banner += "       vagrant scp [vm_name]:<remote_path> <local_path>"
             o.separator ""
             o.separator "Options:"

--- a/lib/vagrant/scp/commands/scp.rb
+++ b/lib/vagrant/scp/commands/scp.rb
@@ -15,16 +15,16 @@ module VagrantPlugins
           return if @file_2.nil?
 
           with_target_vms(host) do |machine|
-            ssh_info = machine.ssh_info
-            raise Vagrant::Errors::SSHNotReady if ssh_info.nil?
+            @ssh_info = machine.ssh_info
+            raise Vagrant::Errors::SSHNotReady if @ssh_info.nil?
 
             Net::SCP.send net_ssh_command,
-                          ssh_info[:host],
-                          ssh_info[:username],
+                          @ssh_info[:host],
+                          @ssh_info[:username],
                           source_files,
                           target_files,
                           :recursive => true,
-                          :ssh => {:port => ssh_info[:port], :keys => ssh_info[:private_key_path]}
+                          :ssh => {:port => @ssh_info[:port], :keys => @ssh_info[:private_key_path]}
           end
         end
 
@@ -55,11 +55,19 @@ module VagrantPlugins
         end
 
         def source_files
-          @file_1.split(':').last
+          format_file_path(@file_1)
         end
 
         def target_files
-          @file_2.split(':').last
+          format_file_path(@file_2)
+        end
+
+        def format_file_path(filepath)
+          if @file_1.include?(':')
+            filepath.split(':').last.gsub("~", "/home/#{@ssh_info[:username]}")
+          else
+            filepath
+          end
         end
 
       end


### PR DESCRIPTION
## Intent

Allow non-unix platforms to make use of this plugin by using the pure-ruby implementation of scp, https://github.com/net-ssh/net-scp.  This is included with vagrant already:

https://github.com/mitchellh/vagrant/blob/master/vagrant.gemspec#L27

So no extra external dependencies are actually necessary.  This would allow Windows hosts to use the plugin (in theory... need to test that still), and provide the same functionality as before.
## Changes
- The `system` command code has been completely removed in favor of the `Net::SCP` interface, which now handles the uploads and downloads.
- Refactored local variables in to private helper methods for clarity, and easier testing (if a test suite were to be implemented in the future).
  - The following methods were added:
    - `host`:  Gets the VM host name from the two file paths.  Defaults to host.
    - `source_files`:  The file path only parsed from the first file path passed in
    - `target_files`:  The file path only parsed from the second file path passed in
  - Note:  `.split(':').last` will return the whole string if there is no `:` in the string, so the same behavior should remain even though we are doing a split every time now.
- Added `.ruby-version` and `.ruby-gemset` files to the `.gitignore`.  Wasn't sure if we wanted to add them to this repository, so I left the ignored so I personally could make use of them without adding them to this repository.
## Testing these changes
- Checkout this branch
- `bundle`
- Add a barebones `Vagrantfile` to this folder and boot up the vm.  The following is the `Vagrantfile` that I used:
  
  ``` ruby
  Vagrant.configure(2) do |config|
    config.vm.box = "opscode-ubuntu-12.04"
  end
  ```
- Test a few uploads and downloads.  The following are some examples:
  
  ```
  $ vagrant scp default:/home/vagrant/.vbox_version ./
  $ vagrant scp lib default:/home/vagrant/
  ```
## TODO
- ~~Currently `~/` type paths do not work with `Net::SCP`.  A hack could be done to make this possible, but it might also be doable with the `:shell` option for `Net::SCP`.~~  Hack in place for `~` on remote hosts... though it is kinda "janky", and assumes the home directory is `/home/[SSH_USERNAME]`, so it might not work on all hosts.  Since a full path can just be used. this should be alright though for a convenience for now.
