### PR TITLE
IdentitiesOnly=yes

### DIFF
--- a/lib/vagrant/scp/commands/scp.rb
+++ b/lib/vagrant/scp/commands/scp.rb
@@ -34,6 +34,7 @@ module VagrantPlugins
             command = [
               "scp",
               "-r",
+              "-o IdentitiesOnly=yes",
               "-o StrictHostKeyChecking=no",
               "-o UserKnownHostsFile=/dev/null",
               "-o port=#{@ssh_info[:port]}",


### PR DESCRIPTION
If you have many entries in you `.ssh/` you must use `IdentitiesOnly=yes`.
Or ssh/scp will complain about "Too many authentication failures for vagrant".

I assume all vagrant boxes are configured with a private key, so I see no reason not to always do this...
