### PR TITLE
use source file name when target file name isn't specified

### DIFF
--- a/lib/vagrant/scp/commands/scp.rb
+++ b/lib/vagrant/scp/commands/scp.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 
 module VagrantPlugins
   module Scp
@@ -77,7 +78,11 @@ module VagrantPlugins
         end
 
         def target_files
-          format_file_path(@file_2)
+          if target_location_specified?
+            format_file_path(@file_2)
+          else
+            Pathname.new(source_files).basename
+          end
         end
 
         def format_file_path(filepath)
@@ -88,6 +93,9 @@ module VagrantPlugins
           end
         end
 
+        def target_location_specified?
+          !@file_2.end_with?(':')
+        end
       end
 
     end


### PR DESCRIPTION
Currently, there is a problem that happens when one tries to copy a file without specifying an exact target location i.e.

`vagrant scp file box:`

In this situation the `file` gets copied to the vm called `box` and saved with the name `box`.

This PR chanes this behavior so that the original file name is used.

This also is described in #26.