### PR TITLE
Use only identities passed on command line

### DIFF
--- a/lib/vagrant/scp/commands/scp.rb
+++ b/lib/vagrant/scp/commands/scp.rb
@@ -40,6 +40,7 @@ module VagrantPlugins
               "-o port=#{@ssh_info[:port]}",
               proxy_command,
               "-i '#{@ssh_info[:private_key_path][0]}'",
+              "-o IdentitiesOnly=yes",
               source,
               target
             ].join(' ')


### PR DESCRIPTION
Without this option, ssh will also try other key pairs available in ~/.ssh/;
if there are too many of these this can cause an authentication error.