### PR TITLE
Add support to use a custom SSH configuration file

### DIFF
--- a/lib/vagrant/scp/commands/scp.rb
+++ b/lib/vagrant/scp/commands/scp.rb
@@ -32,9 +32,16 @@ module VagrantPlugins
               proxy_command = ''
             end
 
+            if @ssh_info[:config]
+              ssh_config = "-F #{@ssh_info[:config]}"
+            else
+              ssh_config = ''
+            end
+
             command = [
               "scp",
               "-r",
+              ssh_config,
               "-o StrictHostKeyChecking=no",
               "-o UserKnownHostsFile=/dev/null",
               "-o port=#{@ssh_info[:port]}",


### PR DESCRIPTION
`vagrant` allows to specify a custom _SSH configuration file_ with

```ruby
Vagrant.configure("2") do |config|
  config.ssh.config = ".ssh/config"
  [...]
end
```

This patch makes `scp` use this custom _SSH configuration file_