### PR TITLE
split the path in exactly two parts so it works on windows too

### DIFF
--- a/lib/vagrant/scp/commands/scp.rb
+++ b/lib/vagrant/scp/commands/scp.rb
@@ -88,7 +88,7 @@ module VagrantPlugins
 
         def format_file_path(filepath)
           if filepath.include?(':')
-            filepath.split(':').last.gsub("~", "/home/#{@ssh_info[:username]}")
+            filepath.split(':', 2).last.gsub("~", "/home/#{@ssh_info[:username]}")
           else
             filepath
           end


### PR DESCRIPTION
on windows, the following now works:

```bash
vagrant scp ':d:/temp/filename-*.7z' .
```

to clarify, this now works with the [Windows flavor of OpenSSH, Win32-OpenSSH](https://github.com/PowerShell/Win32-OpenSSH). I tested this by copying a file from a remote windows guest to a local ubuntu host.